### PR TITLE
Add support for in-browser workers at `/worker`

### DIFF
--- a/convex/workers.ts
+++ b/convex/workers.ts
@@ -251,7 +251,7 @@ export const submitWork = workerMutation({
   },
 });
 
-export const signMeUp = internalMutation({
+export const signMeUp = mutation({
   args: { name: v.optional(v.string()) },
   handler: async (ctx, args) => {
     const apiKey = crypto.randomUUID();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",
+        "@mlc-ai/web-llm": "^0.2.35",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-aspect-ratio": "^1.0.3",
@@ -1019,6 +1020,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/@mlc-ai/web-llm": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.35.tgz",
+      "integrity": "sha512-ud56bL4A1jluQSP24TPAMvda08AN89WC7NlpjIqCcYWw3xd4wDYmgJ9RnusqFYE8hLF+jrEYG3yUvAbWDHgfoQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.7",
     "class-variance-authority": "^0.7.0",
+    "@mlc-ai/web-llm": "^0.2.35",
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
     "convex": "^1.10.0",

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -192,7 +192,7 @@ function SendMessage() {
   );
 }
 
-function Send(props: React.ComponentPropsWithoutRef<"button">) {
+export function Send(props: React.ComponentPropsWithoutRef<"button">) {
   return (
     <button {...props}>
       <svg

--- a/src/LlamaWorker.tsx
+++ b/src/LlamaWorker.tsx
@@ -1,0 +1,275 @@
+import { Button } from "@/components/ui/button";
+import { FormEvent, MouseEvent, useCallback, useEffect, useState } from "react";
+import * as webllm from "@mlc-ai/web-llm";
+import * as Progress from "@radix-ui/react-progress";
+import { Input } from "./components/ui/input";
+import { Send } from "./Chat";
+import { ConvexReactClient, useConvex } from "convex/react";
+import { ConvexClient } from "convex/browser";
+import { api } from "@convex/_generated/api";
+import { FunctionReturnType } from "convex/server";
+import { WorkerHeartbeatInterval } from "@shared/config";
+import { hasDelimeter } from "worker/client";
+
+type LoadingState = { progress: number; text: string };
+
+const MODEL = "TinyLlama-1.1B-Chat-v0.4-q4f32_1-1k";
+// "Llama-3-8B-Instruct-q4f16_1",
+
+class Llama {
+  disposed = false;
+
+  static async load(
+    loadingCb: (loading: LoadingState) => void,
+    client: ConvexClient,
+    apiKey: string
+  ) {
+    loadingCb({ progress: 0, text: "Starting..." });
+    const url = new URL("./lib/llamaWebWorker.ts", import.meta.url);
+    const worker = new Worker(url, { type: "module" });
+    const appConfig = webllm.prebuiltAppConfig;
+    appConfig.useIndexedDBCache = true;
+    const engine = await webllm.CreateWebWorkerEngine(worker, MODEL, {
+      initProgressCallback: (progressReport) => {
+        console.log(progressReport);
+        loadingCb({
+          progress: progressReport.progress * 100,
+          text: progressReport.text,
+        });
+      },
+      appConfig,
+    });
+    return new Llama(worker, engine, client, apiKey);
+  }
+
+  constructor(
+    private worker: Worker,
+    public engine: webllm.EngineInterface,
+    private client: ConvexClient,
+    private apiKey: string
+  ) {}
+
+  async dispose() {
+    this.disposed = true;
+    await this.engine.unload();
+    this.worker.terminate();
+  }
+
+  async workLoop() {
+    while (!this.disposed) {
+      let unsubscribe: undefined | (() => void);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          unsubscribe = this.client.onUpdate(
+            api.workers.isThereWork,
+            {},
+            async (isWork) => {
+              if (isWork) {
+                resolve();
+              }
+            },
+            reject
+          );
+        });
+      } finally {
+        if (unsubscribe) {
+          unsubscribe();
+        }
+      }
+      let work = await this.client.mutation(api.workers.giveMeWork, {
+        apiKey: this.apiKey,
+      });
+      while (work && !this.disposed) {
+        const start = Date.now();
+        work = await this.doWork(work);
+        console.log("Finished:", Date.now() - start, "ms");
+      }
+    }
+  }
+
+  async doWork(
+    work: FunctionReturnType<typeof api.workers.giveMeWork>
+  ): Promise<FunctionReturnType<typeof api.workers.giveMeWork>> {
+    if (!work) {
+      return null;
+    }
+    const { messages, jobId } = work;
+    const timerId = setInterval(() => {
+      console.debug("Still working...");
+      this.client
+        .mutation(api.workers.imStillWorking, { apiKey: this.apiKey, jobId })
+        .then(console.log)
+        .catch(console.error);
+    }, WorkerHeartbeatInterval);
+    try {
+      if (work.stream) {
+        const completion = await this.engine.chat.completions.create({
+          stream: true,
+          messages,
+          temperature: 0.5,
+          max_gen_len: 1024,
+        });
+        let response = "";
+        for await (const chunk of completion) {
+          const part = chunk.choices[0].delta.content;
+          if (part) {
+            response += part;
+          }
+          if (hasDelimeter(response)) {
+            await this.client.mutation(api.workers.submitWork, {
+              message: response,
+              state: "streaming",
+              apiKey: this.apiKey,
+              jobId,
+            });
+            response = "";
+          }
+          return this.client.mutation(api.workers.submitWork, {
+            message: response,
+            state: "streaming",
+            apiKey: this.apiKey,
+            jobId,
+          });
+        }
+      } else {
+        const completion = await this.engine.chat.completions.create({
+          stream: false,
+          messages,
+        });
+        const message = completion.choices[0].message;
+        return this.client.mutation(api.workers.submitWork, {
+          message: message.content ?? "",
+          state: "success",
+          apiKey: this.apiKey,
+          jobId,
+        });
+      }
+    } catch (e) {
+      console.error(e);
+      return this.client.mutation(api.workers.submitWork, {
+        message: e instanceof Error ? e.message : String(e),
+        state: "failed",
+        apiKey: this.apiKey,
+        jobId,
+      });
+    } finally {
+      clearInterval(timerId);
+    }
+    throw new Error("Unreachable");
+  }
+}
+
+export function LlamaWorker() {
+  const [loading, setLoading] = useState<LoadingState | null>(null);
+  const [llama, setLlama] = useState<Llama>();
+  const [name, setName] = useState<string>();
+
+  useEffect(() => {
+    () => {
+      llama && void llama.dispose();
+    };
+  }, [llama]);
+  const startLoading = async () => {
+    const client = new ConvexClient(import.meta.env.VITE_CONVEX_URL as string);
+    try {
+      const apiKey = await client.mutation(api.workers.signMeUp, {
+        name,
+      });
+      const llama = await Llama.load(setLoading, client, apiKey);
+      setLlama(llama);
+    } catch (e: any) {
+      console.error("Failed to load model", e);
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  const [messageToSend, setMessageToSend] = useState("");
+  const sendSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!llama || !messageToSend) {
+        return;
+      }
+      const message = messageToSend;
+      setMessageToSend("");
+
+      const completion = await llama.engine.chat.completions.create({
+        stream: true,
+        messages: [{ role: "user", content: message }],
+        temperature: 0.5,
+        max_gen_len: 1024,
+      });
+      let response = "";
+      for await (const chunk of completion) {
+        const curDelta = chunk.choices[0].delta.content;
+        if (curDelta) {
+          response += curDelta;
+        }
+      }
+      console.log(response);
+      const stats = await llama.engine.runtimeStatsText();
+      console.log(stats);
+    },
+    [messageToSend, llama]
+  );
+
+  // TODO:
+  // [ ] Use AI town's waitlist's animated progress bar!
+  return (
+    <div className="flex-1 flex flex-col gap-2 items-center justify-center">
+      <h2 className="text-4xl">Be a Llama!</h2>
+      <p className="text-lg text-center p-4">
+        Did you always want to be a llama when you grew up?
+        <br />
+        Join the llama farm and live your childhood dreams!
+      </p>
+      {!llama && !loading && (
+        <Button
+          variant={"default"}
+          disabled={!!loading}
+          onClick={() => void startLoading()}
+        >
+          Download model
+        </Button>
+      )}
+      {!!loading && (
+        <>
+          <Progress.Root
+            value={loading.progress}
+            className="relative overflow-hidden bg-my-neutral-sprout rounded-full w-[300px] h-[25px]"
+            style={{ transform: "translateZ(0)" }}
+          >
+            <Progress.Indicator
+              className="bg-my-light-green w-full h-full transition-transform duration-[660ms] ease-[cubic-bezier(0.65, 0, 0.35, 1)]"
+              style={{ transform: `translateX(-${100 - loading.progress}%)` }}
+            />
+          </Progress.Root>
+          <p className="text-small text-center p-4 max-w-lg">{loading.text}</p>
+        </>
+      )}
+      {llama && (
+        <form
+          className="p-2 mt-4 flex items-center gap-2"
+          onSubmit={(e) => void sendSubmit(e)}
+        >
+          <Input
+            type="text"
+            value={messageToSend}
+            onChange={(e) => setMessageToSend(e.target.value)}
+            className="flex-1 resize-none bg-my-neutral-sprout dark:placeholder-my-dark-green dark:text-my-light-tusk dark:bg-my-light-green"
+            placeholder="Type your message..."
+          />
+          <Send
+            type="submit"
+            className={
+              "my-light-green fill-my-light-green disabled:cursor-not-allowed"
+            }
+            title={"hi"}
+            disabled={false}
+          />
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/lib/llamaWebWorker.ts
+++ b/src/lib/llamaWebWorker.ts
@@ -1,0 +1,8 @@
+import { EngineWorkerHandler, Engine } from "@mlc-ai/web-llm";
+
+// Hookup an engine to a worker handler
+const engine = new Engine();
+const handler = new EngineWorkerHandler(engine);
+self.onmessage = (msg: MessageEvent) => {
+  handler.onmessage(msg);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { useLocalStorage } from "usehooks-ts";
 
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import { LlamaWorker } from "./LlamaWorker";
 dayjs.extend(relativeTime);
 
 const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
@@ -22,6 +23,10 @@ const router = createBrowserRouter(
       errorElement: <EmptyPage />,
       element: <App />,
       children: [
+        {
+          path: "/worker",
+          element: <LlamaWorker />,
+        },
         {
           path: "/:uuid",
           element: <Chat />,

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,27 @@
+export enum Model {
+  MISTRAL_7B_INSTRUCT_V0_2_Q4F16_1 = "Mistral-7B-Instruct-v0.2-q4f16_1",
+  LLAMA_3_8B_INSTRUCT_Q4F16_1 = "Llama-3-8B-Instruct-q4f16_1",
+  TINYLAMA_1_1B_CHAT_V0_4_Q4F32_1_1K = "TinyLlama-1.1B-Chat-v0.4-q4f32_1-1k",
+  PHI1_5_Q4F16_1_1K = "Phi1.5-q4f16_1-1k",
+}
+
+export const MODEL_DESCRIPTIONS: {
+  [key in Model]: { displayName: string; icon: string };
+} = {
+  "Llama-3-8B-Instruct-q4f16_1": {
+    displayName: "Llama 3",
+    icon: "🦙",
+  },
+  "Mistral-7B-Instruct-v0.2-q4f16_1": {
+    displayName: "Mistral 7B",
+    icon: "🌬️",
+  },
+  "TinyLlama-1.1B-Chat-v0.4-q4f32_1-1k": {
+    displayName: "TinyLlama",
+    icon: "🦙",
+  },
+  "Phi1.5-q4f16_1-1k": {
+    displayName: "Phi 1.5",
+    icon: "🦙",
+  },
+};

--- a/worker/client.ts
+++ b/worker/client.ts
@@ -112,7 +112,7 @@ async function doWork(
   }
 }
 
-function hasDelimeter(response: string) {
+export function hasDelimeter(response: string) {
   return (
     response.includes("\n") ||
     response.includes(".") ||


### PR DESCRIPTION
@ianmacartney, I just hacked this together as quickly as possible, but I'd be curious if this model makes sense before cleaning it up. do we want untrusted users to be able to join the compute pool?