### PR TITLE
Minor update to canonical URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Free group chat with crowd-sourced LLM responses." />
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:url" content="https://labs.convex.dev/llama-farm/" />
+    <meta property="og:url" content="https://labs.convex.dev/llama-farm" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="llama farm chat" />
     <meta property="og:description" content="Free group chat with crowd-sourced LLM responses." />


### PR DESCRIPTION
Tiny change to the canonical URL, as https://labs.convex.dev/llama-farm/ redirects to https://labs.convex.dev/llama-farm (without the trailing slash) and the Ahrefs report indicates this could cause issues with search engine indexing.